### PR TITLE
[env-config] Bring package up to our current patterns

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ coverage
 .tap-output
 Jenkinsfile
 tools
+test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 library 'magic-butler-catalogue'
 
-def projectName = "env-config-node"
-def repo = "logdna/${projectName}"
+def PROJECT_NAME = "env-config-node"
+def repo = "logdna/${PROJECT_NAME}"
 
 pipeline {
   agent none
@@ -91,6 +91,7 @@ pipeline {
       agent {
         docker {
           image "us.gcr.io/logdna-k8s/node:12-ci"
+          customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
         }
       }
 
@@ -121,6 +122,7 @@ pipeline {
       agent {
         docker {
           image "us.gcr.io/logdna-k8s/node:12-ci"
+          customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
         }
       }
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2020 LogDNA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/logdna/env-config-node/badge.svg?branch=master)](https://coveralls.io/github/logdna/env-config-node?branch=master)
+
 # @logdna/env-config
 
 > Node.js Package to define, document, and assert environment variables

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/logdna/env-config-node",
   "author": "LogDNA, Inc.",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "eslintConfig": {
     "root": true,
     "ignorePatterns": [


### PR DESCRIPTION
**fix: Jenkinsfile needs individual workspaces**

For Docker builds, each stage should have a dedicated
workspace or we could get conflicts when the versioner
tries to check out the main branch.

Semver: patch
Ref: LOG-7634

---

**feat: Add code coverage badge to README**

Semver: patch
Ref: LOG-7634

---

**fix: Add test to .npmignore**

This will decrease the package size

Semver: patch
Ref: LOG-7634

---

**package: Add LICENSE**

Our larger license should be included in a separate
file.

Semver: patch
Ref: LOG-7634