### PR TITLE
fix: Do not throw errors until `validateEnvVars` is called

### DIFF
--- a/lib/definition.js
+++ b/lib/definition.js
@@ -163,16 +163,6 @@ module.exports = class Definition {
     const value_is_missing = !has(process.env, this._env)
       || process.env[this._env] === EMPTY_STRING
 
-    if (this._required) {
-      if (value_is_missing) {
-        const err = new MissingEnvError({
-          type: this._type
-        , name: this._env
-        })
-        throw err
-      }
-    }
-
     if (value_is_missing) {
       if (this._default !== null && !this._allow_empty) {
         this._value = this._transform(this._default)
@@ -190,6 +180,18 @@ module.exports = class Definition {
       , name: this._env
       })
       throw err
+    }
+    if (this._required) {
+      const value_is_missing = !has(process.env, this._env)
+        || process.env[this._env] === EMPTY_STRING
+
+      if (value_is_missing) {
+        const err = new MissingEnvError({
+          type: this._type
+        , name: this._env
+        })
+        throw err
+      }
     }
   }
 

--- a/test/bin.js
+++ b/test/bin.js
@@ -24,12 +24,7 @@ test('bin', async (t) => {
     const fixture = path.join(__dirname, 'fixtures/config.js')
     const output_fp = path.join(__dirname, 'fixtures/output.md')
     const output = await readFile(output_fp, 'utf8')
-    const {stdout} = await exec(`${bin} ${fixture}`, {
-      env: {
-        ...process.env
-      , MY_STRING: 'my-string-value'
-      }
-    })
+    const {stdout} = await exec(`${bin} ${fixture}`)
     t.equal(stdout, output, 'stdout is correct')
   })
 })


### PR DESCRIPTION
Running `cmd.js` against a config outputs the `toMarkdown()`
result. This has no need to actually use or parse the env
variables, so it should not throw errors for missing
required variables. This error was introduced on the last
major refactor.

Ref: LOG-13202